### PR TITLE
Set read_replicas_mode default to null

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -56,7 +56,7 @@ variable "replica_count" {
 variable "read_replicas_mode" {
   description = "Read replicas mode. https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#readreplicasmode "
   type        = string
-  default     = "READ_REPLICAS_DISABLED"
+  default     = null
 }
 
 variable "location_id" {


### PR DESCRIPTION
Even if you apply it as READ_REPLICAS_DISABLED it does not set and causes a terraform drift